### PR TITLE
feat(traceroute): add callback support and stop method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2469,6 +2469,7 @@ name = "traceroute"
 version = "0.1.0"
 dependencies = [
  "buffer",
+ "lazy_static",
  "napi-build-ohos",
  "napi-derive-ohos",
  "napi-ohos",

--- a/crates/traceroute/Cargo.toml
+++ b/crates/traceroute/Cargo.toml
@@ -16,6 +16,7 @@ buffer           = { workspace = true }
 nix              = { workspace = true, features = ["net", "socket", "uio"] }
 
 ohos-hilog-binding = { workspace = true }
+lazy_static = "1.5.0"
 
 [build-dependencies]
 napi-build-ohos = { workspace = true }


### PR DESCRIPTION
Functionality: Supports passing in a callback to promptly obtain information for each hop, and allows actively stopping an ongoing trace.

API:

`export declare function stopTrace(): void

export declare function setTraceListener(func: any): void

export declare function getTraceResult(): HopResult | null`

Usage:

// Start tracing
`traceRoute("8.8.8.8");

// Set up a listener, which will be called whenever a new hop is recorded
setTraceListener(() => {
  let hopResult = getTraceResult() // Get the latest trace result
  console.log(`traceRoute_hopResult: ${JSON.stringify(hopResult)}`)
})

// Can actively stop the trace
stopTrace()`

Legacy Issue: Not being familiar with Rust, data cannot be passed through callbacks, hence the approach of actively querying within the callback was used. Is there a better way to implement this?